### PR TITLE
Use a MemoryStream in compilation.Emit instead of outputPath

### DIFF
--- a/MonacoRoslynCompletionProvider/MonacoRoslynCompletionProvider/CompletionWorkspace.cs
+++ b/MonacoRoslynCompletionProvider/MonacoRoslynCompletionProvider/CompletionWorkspace.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Data;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
@@ -78,11 +79,13 @@ namespace MonacoRoslynCompletionProvider
                     references: _metadataReferences
                 );
 
-            var result = compilation.Emit("temp");
-            var semanticModel = compilation.GetSemanticModel(st, true);
-
-            
-            return new CompletionDocument(document, semanticModel, result); 
+            using(var temp = new MemoryStream())
+            {
+                var result = compilation.Emit(temp);
+                var semanticModel = compilation.GetSemanticModel(st, true);
+                
+                return new CompletionDocument(document, semanticModel, result); 
+            }            
         }
     }
 }


### PR DESCRIPTION
Ran into issues using the outputPath in environments where it was not a option to write out a file to the suggested filename "temp" and there was no use-case ( on our end ) where we needed the file itself afterwards

Writing out to a MemoryStream mediated the issue